### PR TITLE
fixed bug so extensions can actuall be loaded on linux

### DIFF
--- a/src/opengl.nim
+++ b/src/opengl.nim
@@ -66,9 +66,9 @@ else:
       symAddr(oglHandle, "wglGetProcAddress"))
   elif defined(linux):
     var glxGetProcAddress = cast[proc (s: cstring): pointer {.cdecl.}](
-      symAddr(oglHandle, "glxGetProcAddress"))
+      symAddr(oglHandle, "glXGetProcAddress"))
     var glxGetProcAddressArb = cast[proc (s: cstring): pointer {.cdecl.}](
-      symAddr(oglHandle, "glxGetProcAddressARB"))
+      symAddr(oglHandle, "glXGetProcAddressARB"))
 
   proc glGetProc(h: LibHandle; procName: cstring): pointer =
     when defined(windows):


### PR DESCRIPTION
[glXGetProcAddress](https://www.opengl.org/sdk/docs/man2/xhtml/glXGetProcAddress.xml) has a capital X, without it `symAddr` will always return _nil_