### PR TITLE
GLshort can't be 64 bit

### DIFF
--- a/src/opengl.nim
+++ b/src/opengl.nim
@@ -117,7 +117,7 @@ type
   GLbitfield* = distinct uint32
   GLvoid* = pointer
   GLbyte* = int8
-  GLshort* = int64
+  GLshort* = int16
   GLint* = int32
   GLclampx* = int32
   GLubyte* = uint8


### PR DESCRIPTION
I just stumbled on this, thought I should fix it instantly before it causes problems. It just a rarely used type so I guess that is the reason why it did not cause problems until now.