### PR TITLE
change opengl AllErrorCodes from set[GLerrorCode] to seq[GLerrorCode]

### DIFF
--- a/src/opengl.nim
+++ b/src/opengl.nim
@@ -226,7 +226,7 @@ type
     glErrInvalidFramebufferOperation = (0x0506, "invalid framebuffer operation")
     glErrTableTooLarge = (0x8031, "table too large")
 
-const AllErrorCodes = {
+const AllErrorCodes = [
     glErrNoError,
     glErrInvalidEnum,
     glErrInvalidValue,
@@ -236,7 +236,7 @@ const AllErrorCodes = {
     glErrOutOfMem,
     glErrInvalidFramebufferOperation,
     glErrTableTooLarge,
-}
+]
 
 when defined(macosx):
   type


### PR DESCRIPTION
avoid allocating huge static array for set[GLerrorCode] in generated C code. (~4KB)