### PR TITLE
Update README.md with workaround for linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ An OpenGL interface
 
 # Automatic error checking
 The OpenGL procs do perform automatic error checking by default. This can be disabled at compile-time by defining the conditional symbol ``noAutoGLerrorCheck`` (-d:noAutoGLerrorCheck), in which case the error checking code will be omitted from the binary; or at run-time by executing this statement: ``enableAutoGLerrorCheck(false)``.
+
+# Building with x11 (linux)
+When receiving the following error:
+```
+<path-to-opengl>/opengl/private/prelude.nim(5, 10) Error: cannot open file: X
+```
+Version 1.2.0 is broken for Linux builds, as x11 is imported incorrectly - use 1.2.2 or greater!


### PR DESCRIPTION
Workaround for an annoying error for new builds of opengl on Linux, even more annoying as the nim package repo lists the highest available version as 1.2.0 (https://nimble.directory/pkg/opengl)