### PR TITLE
Removed glutInit() from the `push` pragma

### DIFF
--- a/src/opengl/glut.nim
+++ b/src/opengl/glut.nim
@@ -247,14 +247,6 @@ const                         # glutGet parameters.
   GLUT_GAME_MODE_DISPLAY_CHANGED* = 6 # GLUT initialization sub-API.
 
 proc glutInit*(argcp: ptr cint, argv: pointer)
-
-proc glutInit*() =
-  ## version that passes `argc` and `argc` implicitely.
-  var
-    cmdLine {.importc: "cmdLine".}: array[0..255, cstring]
-    cmdCount {.importc: "cmdCount".}: cint
-  glutInit(addr(cmdCount), addr(cmdLine))
-
 proc glutInitDisplayMode*(mode: int16)
 proc glutInitDisplayString*(str: cstring)
 proc glutInitWindowPosition*(x, y: int)
@@ -377,3 +369,11 @@ proc glutLeaveGameMode*()
 proc glutGameModeGet*(mode: GLenum): int
 # implementation
 {.pop.} # dynlib: dllname, importc
+
+# Convenience procs
+proc glutInit*() =
+  ## version that passes `argc` and `argc` implicitely.
+  var
+    cmdLine {.importc: "cmdLine".}: array[0..255, cstring]
+    cmdCount {.importc: "cmdCount".}: cint
+  glutInit(addr(cmdCount), addr(cmdLine))


### PR DESCRIPTION
The convenience procedure `glutInit()` without arguments has to be a normal Nim proc, not imported from the dynamic library as it is now (because it's currently inside the `push` pragma that starts at line 99).

This fixes issue #70 