### PR TITLE
Update `prelude.nim`

### DIFF
--- a/src/opengl/private/prelude.nim
+++ b/src/opengl/private/prelude.nim
@@ -21,6 +21,13 @@ when defined(useGlew):
   {.pragma: oglx, header: "<GL/glxew.h>".}
   {.pragma: wgl, header: "<GL/wglew.h>".}
   {.pragma: glu, dynlib: gludll.}
+  
+  when defined(linux) or defined(windows):
+    {.passC: "-flto -useGlew".}
+    when defined(windows):
+      {.passL: "-lglew32 -lopengl32".}
+    elif defined(linux):
+      {.passL: "-lGLEW -lGL".}
 elif defined(ios):
   {.pragma: ogl.}
   {.pragma: oglx.}

--- a/src/opengl/private/prelude.nim
+++ b/src/opengl/private/prelude.nim
@@ -22,9 +22,9 @@ when defined(useGlew):
   {.pragma: wgl, header: "<GL/wglew.h>".}
   {.pragma: glu, dynlib: gludll.}
   
-  proc glewInit()*: GLenum {.importc.}
+  proc glewInit*(): GLenum {.importc.}
   
-  proc loadExtensions()*: Glenum =
+  proc loadExtensions*(): Glenum =
     ## Just alias for glewInit
     glewInit()
 elif defined(ios):

--- a/src/opengl/private/prelude.nim
+++ b/src/opengl/private/prelude.nim
@@ -21,12 +21,6 @@ when defined(useGlew):
   {.pragma: oglx, header: "<GL/glxew.h>".}
   {.pragma: wgl, header: "<GL/wglew.h>".}
   {.pragma: glu, dynlib: gludll.}
-  
-  proc glewInit*(): GLenum {.importc.}
-  
-  proc loadExtensions*(): Glenum =
-    ## Just alias for glewInit
-    glewInit()
 elif defined(ios):
   {.pragma: ogl.}
   {.pragma: oglx.}

--- a/src/opengl/private/prelude.nim
+++ b/src/opengl/private/prelude.nim
@@ -21,6 +21,12 @@ when defined(useGlew):
   {.pragma: oglx, header: "<GL/glxew.h>".}
   {.pragma: wgl, header: "<GL/wglew.h>".}
   {.pragma: glu, dynlib: gludll.}
+  
+  proc glewInit()*: GLenum {.importc.}
+  
+  proc loadExtensions()*: Glenum =
+    ## Just alias for glewInit
+    glewInit()
 elif defined(ios):
   {.pragma: ogl.}
   {.pragma: oglx.}

--- a/src/opengl/private/types.nim
+++ b/src/opengl/private/types.nim
@@ -111,3 +111,6 @@ proc `==`*(a, b: GLenum): bool {.borrow.}
 proc `==`*(a, b: GLbitfield): bool {.borrow.}
 proc `or`*(a, b: GLbitfield): GLbitfield {.borrow.}
 proc hash*(x: GLenum): int = x.int
+
+when defined(useGlew):
+  proc glewInit*(): GLenum {.importc.}


### PR DESCRIPTION
Makes it a little easier to use the library. The user does not need to specify the necessary flags.