### PR TITLE
bump to 1.2.9 in order to fix the pre-existing wrong tag

### DIFF
--- a/opengl.nimble
+++ b/opengl.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "1.2.8"
+version = "1.2.9"
 author = "Andreas Rumpf"
 description = "an OpenGL wrapper"
 license = "MIT"


### PR DESCRIPTION
There is already a tag for 1.2.8, but the version of this file wasn't updated properly